### PR TITLE
Fix possible SQL injection in payload

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -422,7 +422,10 @@ export class PostgresAdapter extends Adapter {
         document.type,
         this.channel
       );
-      await this.pool.query(`NOTIFY "${this.channel}", '${payload}'`);
+      await this.pool.query(`SELECT pg_notify($1, $2)`, [
+        this.channel,
+        payload,
+      ]);
 
       this.scheduleHeartbeat();
     } catch (err) {
@@ -448,7 +451,7 @@ export class PostgresAdapter extends Adapter {
       type: document.type,
       attachmentId,
     });
-    this.pool.query(`NOTIFY "${this.channel}", '${headerPayload}'`);
+    this.pool.query(`SELECT pg_notify($1, $2)`, [this.channel, headerPayload]);
   }
 
   /**


### PR DESCRIPTION
While testing the lib to scale our messaging service across multiple instance, we found that some messages triggered an error.
Those message all contained the `'` character, and after a quick review of the source code we found that the payload is directly used in building the request, which allow SQL injections.
To fix that, I used parameterized queries when sending the NOTIFY command -> https://node-postgres.com/features/queries#parameterized-query

Another possible SQL injection concern the `tableName` and `cleanupInterval` variables, but is much harder to exploit as it requires the attacker to have access to the source code and/or configuration of the program using this lib.