### PR TITLE
Add errorHandler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ pool.query(`
   );
 `);
 
+pool.on("error", (err) => {
+  console.error("Postgres error", err);
+});
+
 io.adapter(createAdapter(pool));
 io.listen(3000);
 ```

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -127,7 +127,7 @@ export function createAdapter(
   pool: any,
   opts: Partial<PostgresAdapterOptions> = {}
 ) {
-  return function (nsp) {
+  return function (nsp: any) {
     return new PostgresAdapter(nsp, pool, opts);
   };
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -80,6 +80,7 @@ export interface PostgresAdapterOptions {
   channelPrefix: string;
   /**
    * The name of the table for payloads over the 8000 bytes limit or containing binary data
+   * @default "socket_io_attachments"
    */
   tableName: string;
   /**
@@ -107,6 +108,11 @@ export interface PostgresAdapterOptions {
    * @default 30000
    */
   cleanupInterval: number;
+  /**
+   * Handler for errors. If undefined, it will terminate the process when an error occurs (see https://nodejs.org/api/events.html#error-events).
+   * @default undefined
+   */
+  errorHandler: (err: any) => void | undefined
 }
 
 /**
@@ -122,7 +128,11 @@ export function createAdapter(
   opts: Partial<PostgresAdapterOptions> = {}
 ) {
   return function (nsp) {
-    return new PostgresAdapter(nsp, pool, opts);
+    const postgresAdapter = new PostgresAdapter(nsp, pool, opts);
+    if (opts.errorHandler) {
+      postgresAdapter.on("error", opts.errorHandler);
+    }
+    return postgresAdapter;
   };
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -171,8 +171,8 @@ export class PostgresAdapter extends Adapter {
     this.heartbeatTimeout = opts.heartbeatTimeout || 10000;
     this.payloadThreshold = opts.payloadThreshold || 8000;
     this.cleanupInterval = opts.cleanupInterval || 30000;
-    const defaultErrorHandler = (err: any) => this.emit("error", err);
-    this.errorHandler = opts.errorHandler || defaultErrorHandler
+    const defaultErrorHandler = (err: any) => debug(err);
+    this.errorHandler = opts.errorHandler || defaultErrorHandler;
 
     this.initSubscription();
     this.publish({


### PR DESCRIPTION
It might happen that:
- The user starts the server
- PostgreSQL crashes or reboots
- In that case the connection pool is lost. 

There is code to reconnect, but that's not executed as an uncaughtException is thrown. This is because `this.emit("error", err);` will cause the Node process to exit, as explained on https://nodejs.org/api/events.html#error-events

It would be better to offer the option to handle these errors. 

Alternative would be to mention in the readme that errors can be handled when creating the adapter:
```
io.adapter(function (nsp) {
  const adapter = new PostgresAdapter(nsp, pool, {})
  adapter.on("error", (e) => {
    console.error("Postgres adapter error", e)
  })
  return adapter
})
```

The arrow notation (so `io.adapter((nsp) => {` instead of `io.adapter(function (nsp) {`) won't work in this case.