### PR TITLE
fix: do not emit "error" events

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ pool.query(`
 `);
 
 io.adapter(createAdapter(pool));
+
+pool.on("error", (err) => {
+  // ...
+});
+
 io.listen(3000);
 ```
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -198,7 +198,7 @@ export class PostgresAdapter extends Adapter {
         try {
           await this.onEvent(msg.payload);
         } catch (err) {
-          this.emit("error", err);
+          debug("an error has occurred while handling the notification");
         }
       });
 
@@ -213,7 +213,6 @@ export class PostgresAdapter extends Adapter {
 
       this.client = client;
     } catch (err) {
-      this.emit("error", err);
       debug("error while initializing client, scheduling reconnection...");
       this.scheduleReconnection();
     }
@@ -391,7 +390,7 @@ export class PostgresAdapter extends Adapter {
           `DELETE FROM ${this.tableName} WHERE created_at < now() - interval '${this.cleanupInterval} milliseconds'`
         );
       } catch (err) {
-        this.emit("error", err);
+        debug("an error has occurred while cleaning up old payloads");
       }
       this.scheduleCleanup();
     }, this.cleanupInterval);
@@ -426,11 +425,11 @@ export class PostgresAdapter extends Adapter {
         this.channel,
         payload,
       ]);
-
-      this.scheduleHeartbeat();
     } catch (err) {
-      this.emit("error", err);
+      debug("an error has occurred while publishing a new notification");
     }
+
+    this.scheduleHeartbeat();
   }
 
   private async publishWithAttachment(document: any) {


### PR DESCRIPTION
Forcing users to handle "error" events is useless since there is no
interesting way to handle them (no retry, for example).

Before:

```js
io.adapter(createAdapter(pool));

poll.on("error", (err) => {
  // client disconnection
});

io.of("/").adapter.on("error", () => {
  // needed so that no exception is thrown
});
```

After:

```js
io.adapter(createAdapter(pool));

poll.on("error", (err) => {
  // client disconnection
})
```