### PR TITLE
Fix for payload exactly 8000 bytes

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -170,7 +170,7 @@ export class PubSubClient {
       }
 
       const payload = JSON.stringify(message);
-      if (Buffer.byteLength(payload) > this.opts.payloadThreshold) {
+      if (Buffer.byteLength(payload) >= this.opts.payloadThreshold) {
         return this.publishWithAttachment(message);
       }
 


### PR DESCRIPTION
When the `payload` is exactly 8000 bytes, PostgreSQL will give an error `payload string too long`